### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ To use this app, you must have:
 
 ---
 
+## 🛠️ Troubleshooting
+
+- **API key missing**: Ensure the `OPENAI_API_KEY` environment variable is set or provided in a `.env` file.
+- **Network timeout**: Check your internet connection and try again. If the problem persists, the OpenAI service may be temporarily unavailable.
+
+---
+
 ## 🤝 Contributing
 
 Want to suggest rhyme logic improvements, rhyme corpus integration, or add offline fallback?  


### PR DESCRIPTION
## Summary
- raise `MissingAPIKeyError` when `OPENAI_API_KEY` is absent and wrap network failures in `OpenAIRequestError`
- show user-friendly messages in the Gradio interface when these errors occur
- document troubleshooting steps for missing API key or network timeouts

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb2ffec51883229d6729919b1aa52e