### PR TITLE
Handle OpenAI client initialization errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ To use this app, you must have:
 ## 🛠️ Troubleshooting
 
 - **API key missing**: Ensure the `OPENAI_API_KEY` environment variable is set or provided in a `.env` file.
-- **Network timeout**: Check your internet connection and try again. If the problem persists, the OpenAI service may be temporarily unavailable.
+- **Invalid API key**: Double-check that the key has no typos and that your OpenAI account has API access.
+- **Network timeout or connection error**: Verify your internet connection and firewall settings, then try again. The OpenAI service may also be temporarily unavailable.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `OpenAIClientError` and raise it in `_get_openai_client` for client init failures
- Allow `query_rhyme_score` to propagate custom errors
- Surface friendly error messages in `analyze_rhyme`
- Document API key and connection troubleshooting tips in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb31f8f5a883228450e84fb30f0cbd