### PR TITLE
Bundle CMUdict subset and add phonetic engine smoke test

### DIFF
--- a/app.py
+++ b/app.py
@@ -330,13 +330,14 @@ class PhoneticEngine:
         }
 
         # Load CMUdict
-        cmu_path = os.path.join(os.path.dirname(__file__), "cmudict-0.7b")
-        if os.path.exists(cmu_path):
+        cmu_path = os.path.join(os.path.dirname(__file__), "data", "cmudict-0.7b")
+        try:
             self.cmudict = load_cmudict(cmu_path)
-            print(f"✓ Loaded CMUdict with {len(self.cmudict):,} entries")
-        else:
+        except (FileNotFoundError, OSError):
             self.cmudict = {}
             print("⚠️ CMUdict file not found, using fallback dictionary")
+        else:
+            print(f"✓ Loaded CMUdict with {len(self.cmudict):,} entries")
 
         # Keep the fallback phoneme dictionary for testing
         self.phoneme_dict = self._build_phoneme_dictionary()

--- a/data/cmudict-0.7b
+++ b/data/cmudict-0.7b
@@ -1,0 +1,9 @@
+;;; CMU Pronouncing Dictionary (subset)
+;;; Original data source: Carnegie Mellon University
+HAT  HH AE1 T
+CAT  K AE1 T
+BAT  B AE1 T
+MAT  M AE1 T
+CHAT  CH AE1 T
+THAT  DH AE1 T
+FLAT  F L AE1 T

--- a/tests/test_phonetic_engine.py
+++ b/tests/test_phonetic_engine.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app import PhoneticEngine
+
+
+def test_phonetic_engine_loads_cmudict():
+    engine = PhoneticEngine()
+    assert engine.cmudict, "Expected CMUdict to be loaded with entries"
+    assert engine.get_phonemes("hat") == "HH AE1 T"


### PR DESCRIPTION
## Summary
- add a bundled CMUdict subset under `data/`
- update `PhoneticEngine` to load the bundled dictionary path
- add a smoke test that verifies the dictionary loads and a known entry resolves phonemes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddf2d1c7ac8322aa8e5356302425f6