### PR TITLE
Expand lexicon ingestion and add rhyme regression tests

### DIFF
--- a/tests/test_regression_rhymes.py
+++ b/tests/test_regression_rhymes.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+import pytest
+
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app import IntegratedRhymeGenerator
+
+
+@pytest.fixture(scope="module")
+def integrated_generator():
+    # Disable cultural analysis to keep tests fast and deterministic.
+    generator = IntegratedRhymeGenerator()
+    return generator
+
+
+@pytest.mark.parametrize("word", ["chesterfield", "window"])
+def test_regression_rhymes_available(integrated_generator, word):
+    results = integrated_generator.find_fully_integrated_rhymes(
+        word,
+        quality_threshold=10,  # allow near rhymes for regression coverage
+        max_results=20,
+        use_cultural_analysis=False,
+    )
+
+    assert results, f"Expected at least one rhyme candidate for '{word}'"


### PR DESCRIPTION
## Summary
- load the CMU dictionary-derived lexicon in `UncommonRhymeGenerator` with curated fallbacks
- refresh the integrated generator word list to use the expanded lexicon and optional frequency metadata
- add regression tests to ensure words like “chesterfield” and “window” now return rhyme candidates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddf34ca40083229eb88ffd17e9e5f1