### PR TITLE
Improve phoneme generation for unseen words

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ cd rhyme-rarity-checker
 pip install -r requirements.txt
 ```
 
+`phonemizer` relies on the [espeak](http://espeak.sourceforge.net/) backend. Install it via your system package manager, e.g.
+
+```bash
+sudo apt-get install espeak
+# or on macOS
+brew install espeak
+```
+
 ### 3. Add your OpenAI API key
 Create a `.env` file:
 ```env
@@ -91,6 +99,8 @@ From `requirements.txt`:
 openai>=1.3.0
 gradio
 pytest
+phonemizer
+python-Levenshtein
 ```
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ openai>=1.3.0
 gradio
 
 pytest
+phonemizer
+python-Levenshtein

--- a/tests/test_phonetic_engine.py
+++ b/tests/test_phonetic_engine.py
@@ -1,12 +1,26 @@
 import os
 import sys
 
+import pytest
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from app import PhoneticEngine
+from app import PHONEMIZER_AVAILABLE, PhoneticEngine
 
 
 def test_phonetic_engine_loads_cmudict():
     engine = PhoneticEngine()
     assert engine.cmudict, "Expected CMUdict to be loaded with entries"
     assert engine.get_phonemes("hat") == "HH AE1 T"
+
+
+@pytest.mark.skipif(not PHONEMIZER_AVAILABLE, reason="phonemizer dependency is required")
+def test_phonemizer_beats_naive_mapping_for_unseen_word():
+    engine = PhoneticEngine()
+    word = "chesterfieldian"
+
+    naive_phonemes = engine._approximate_phonemes(word)
+    phonemized = engine.get_phonemes(word)
+
+    assert phonemized, "Phonemizer should return a phoneme sequence"
+    assert phonemized != naive_phonemes


### PR DESCRIPTION
## Summary
- add phonemizer-related dependencies and document the espeak requirement
- resolve phonemes per token so multi-word inputs leverage the phonemizer before falling back
- add a unit test that checks phonemizer output beats the naive approximation for an unseen word

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddf881d2488322b7676dc4dd3dc8a1